### PR TITLE
feat: remove genre tags in genre pages, add genre header

### DIFF
--- a/gelp/src/app/(auth_optional)/genre/[genreID]/page.tsx
+++ b/gelp/src/app/(auth_optional)/genre/[genreID]/page.tsx
@@ -1,12 +1,43 @@
 import GamesByGenre from "@/app/(auth_optional)/genre/[genreID]/GamesByGenre";
 
+const hash = (str: string) => {
+  let h = 2;
+  for (let i = 0; i < str.length; i++) {
+    h *= str.charCodeAt(i) * 25;
+    h += str.charCodeAt(i);
+    h %= 360;
+  }
+  return h;
+};
+
+const toTitleCase = (str: string) => {
+  if (str === "rpg") return "RPG";
+  if (str === "role-playing (rpg)") return "RPG";
+  if (str === "real time strategy (rts)") return "RTS";
+  if (str === "turn-based strategy (tbs)") return "TBS";
+
+  return str
+    .toLowerCase()
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+};
+
 const GenrePage = async ({params}: { params: Promise<{genreID: string }>}) => {
   let {genreID} = await params;
   genreID = decodeURIComponent(genreID);
+  
+  const color = `hsl(${hash(genreID)}, 65%, 45%)`;
 
   return <main className='min-h-screen bg-black text-white selection:bg-indigo-500/30 p-10'>
     <div className='max-w-7xl mx-auto flex gap-12'>
-      <GamesByGenre genre={genreID}/>
+      <div className="flex flex-col gap-6">
+        <h1 className="text-5xl font-extrabold tracking-tight" style={{ color }}>
+          {toTitleCase(genreID)}
+        </h1>
+
+        <GamesByGenre genre={genreID}/>
+      </div>      
     </div>
   </main>
 }

--- a/gelp/src/components/GameDisplay.tsx
+++ b/gelp/src/components/GameDisplay.tsx
@@ -2,7 +2,6 @@ import {IGame} from "@/db";
 import {FC} from "react";
 import Link from "next/link";
 import mongoose from "mongoose";
-import GenreTag from "@/components/GenreTag";
 import RatingStarDisplay from "@/components/rating/RatingStarDisplay";
 
 type GameDisplayProps = {
@@ -30,7 +29,6 @@ const GameDisplay: FC<GameDisplayProps> = ({game, genre, ratings}) => {
       <div className='flex flex-col p-3 gap-2 relative'>
         <div className='flex justify-between items-center gap-2'>
           <h2 className='text-lg font-bold text-white line-clamp-1'>{game.title}</h2>
-          {genre !==undefined && <GenreTag genre={genre} link={false}/>}
         </div>
 
         <p className="text-sm text-zinc-400 line-clamp-2 leading-snug">


### PR DESCRIPTION
Went through genres, saw "Card & Board Game" just overflowing in the post, found them repetitive per post.

Merge if the ideas is fine.

Resolves #112 